### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/chaos-operator.yaml
+++ b/.github/workflows/chaos-operator.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-chaos
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/db-operator.yaml
+++ b/.github/workflows/db-operator.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-db
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/demoweb-operator.yaml
+++ b/.github/workflows/demoweb-operator.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-demoweb
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/limitrange-np-operator.yaml
+++ b/.github/workflows/limitrange-np-operator.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-limitrange-np
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/primer-operator.yaml
+++ b/.github/workflows/primer-operator.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-primer
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/project-operator.yaml
+++ b/.github/workflows/project-operator.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-project
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/restarter-operator.yaml
+++ b/.github/workflows/restarter-operator.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-restarter
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/shutdown-operator-build-docker.yaml
+++ b/.github/workflows/shutdown-operator-build-docker.yaml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: djkormo/op-shutdown
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore